### PR TITLE
Remove FreeDesktop launcher thumbnail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # StreamController Plugins
 
 This repository contains plugins for [StreamController](https://github.com/Core447/StreamController).  
-Currently it includes the **Steam Friends** plugin located in `com_fernandomema_StreamControllerSteamPlugin`.
+Currently it includes the **Steam Friends** plugin located in `com_fernandomema_StreamControllerSteamPlugin` and the **FreeDesktop Launcher** plugin located in `com_fernandomema_FreeDesktopLauncher`.
 
-The plugin displays your Steam friends and their current status. It requires a Steam Web API key and the SteamID of your account. These can be configured from the plugin settings inside the application.
+The Steam Friends plugin displays your Steam friends and their current status. It requires a Steam Web API key and the SteamID of your account. These can be configured from the plugin settings inside the application.
 
 ## Installation
 

--- a/com_fernandomema_FreeDesktopLauncher/actions/AppLauncher/AppLauncher.py
+++ b/com_fernandomema_FreeDesktopLauncher/actions/AppLauncher/AppLauncher.py
@@ -1,0 +1,39 @@
+from src.backend.PluginManager.ActionBase import ActionBase
+import subprocess
+from PIL import Image
+from gi.repository import Gtk, Gdk
+import os
+
+class AppLauncher(ActionBase):
+    def on_short_press(self):
+        cmd = self.settings.get("exec")
+        if cmd:
+            subprocess.Popen(cmd, shell=True)
+
+    def on_tick(self):
+        name = self.settings.get("name", "")
+        icon_name = self.settings.get("icon")
+        image = None
+        if icon_name:
+            path = self.resolve_icon(icon_name)
+            if path and os.path.exists(path):
+                try:
+                    image = Image.open(path).convert('RGBA')
+                except Exception:
+                    image = None
+        self.set_media(image=image, size=1, valign=0)
+        self.set_label(text=name, position="bottom")
+
+    def resolve_icon(self, icon_name):
+        # Try absolute path first
+        if os.path.isabs(icon_name) and os.path.exists(icon_name):
+            return icon_name
+        theme = Gtk.IconTheme.get_for_display(Gdk.Display.get_default())
+        info = theme.lookup_icon(icon_name, 64, 0)
+        if info:
+            return info.get_filename()
+        # fallback to pixmaps
+        pixmap_path = f"/usr/share/pixmaps/{icon_name}.png"
+        if os.path.exists(pixmap_path):
+            return pixmap_path
+        return None

--- a/com_fernandomema_FreeDesktopLauncher/main.py
+++ b/com_fernandomema_FreeDesktopLauncher/main.py
@@ -1,0 +1,111 @@
+import os
+import json
+import math
+import configparser
+from pathlib import Path
+
+from src.backend.PluginManager.PluginBase import PluginBase
+from src.backend.PluginManager.ActionHolder import ActionHolder
+from src.backend.PluginManager.ActionInputSupport import ActionInputSupport
+from src.backend.DeckManagement.InputIdentifier import Input
+
+from .actions.AppLauncher.AppLauncher import AppLauncher
+
+
+class FreeDesktopLauncherPlugin(PluginBase):
+    ITEMS_PER_PAGE = 15
+
+    def __init__(self):
+        super().__init__()
+        self.lm = self.locale_manager
+
+        self.launcher_holder = ActionHolder(
+            plugin_base=self,
+            action_base=AppLauncher,
+            action_id_suffix="AppLauncher",
+            action_name="Application Launcher",
+            action_support={
+                Input.Key: ActionInputSupport.SUPPORTED,
+                Input.Dial: ActionInputSupport.UNSUPPORTED,
+                Input.Touchscreen: ActionInputSupport.SUPPORTED,
+            },
+        )
+        self.add_action_holder(self.launcher_holder)
+
+        self.register(
+            plugin_name="FreeDesktop Launcher",
+            github_repo="https://github.com/example/FreeDesktopLauncher",
+            plugin_version="1.0.0",
+            app_version="1.2.0-alpha",
+        )
+
+        self.generate_pages()
+
+    def load_desktop_entries(self):
+        paths = [
+            Path("/usr/share/applications"),
+            Path("/usr/local/share/applications"),
+            Path.home() / ".local/share/applications",
+        ]
+        entries = []
+        for base in paths:
+            if not base.exists():
+                continue
+            for f in base.glob("*.desktop"):
+                parser = configparser.ConfigParser(interpolation=None)
+                try:
+                    parser.read(f)
+                except Exception:
+                    continue
+                if not parser.has_section("Desktop Entry"):
+                    continue
+                sect = parser["Desktop Entry"]
+                name = sect.get("Name")
+                exec_cmd = sect.get("Exec")
+                icon = sect.get("Icon")
+                if not name or not exec_cmd:
+                    continue
+                entries.append({"name": name, "exec": exec_cmd, "icon": icon})
+        # sort by name
+        entries.sort(key=lambda e: e["name"].lower())
+        return entries
+
+    def generate_pages(self):
+        entries = self.load_desktop_entries()
+        pages_dir = os.path.join(self.PATH, "pages")
+        os.makedirs(pages_dir, exist_ok=True)
+        per_page = self.ITEMS_PER_PAGE
+        total_pages = math.ceil(len(entries) / per_page) or 1
+        for idx in range(total_pages):
+            chunk = entries[idx * per_page:(idx + 1) * per_page]
+            page = self.create_page(chunk)
+            page_path = os.path.join(pages_dir, f"MenuPage{idx+1}.json")
+            with open(page_path, "w") as fh:
+                json.dump(page, fh, indent=4)
+            self.register_page(page_path)
+
+    def create_page(self, entries):
+        page = {"keys": {"0x0": {}}}
+        positions = [(x, y) for x in range(5) for y in range(3)][1:]
+        for entry, pos in zip(entries, positions):
+            key = f"{pos[0]}x{pos[1]}"
+            page["keys"][key] = {
+                "states": {
+                    "0": {
+                        "actions": [
+                            {
+                                "id": f"{self.plugin_id}::AppLauncher",
+                                "settings": entry,
+                            }
+                        ],
+                        "image-control-action": 0,
+                        "label-control-actions": [0, 0, 0],
+                        "background-control-action": 0,
+                    }
+                }
+            }
+        # Fill remaining positions
+        for pos in positions[len(entries):]:
+            key = f"{pos[0]}x{pos[1]}"
+            page["keys"].setdefault(key, {})
+        return page

--- a/com_fernandomema_FreeDesktopLauncher/manifest.json
+++ b/com_fernandomema_FreeDesktopLauncher/manifest.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "thumbnail": "store/Thumbnail.png",
+    "id": "com_fernandomema_FreeDesktopLauncher",
+    "name": "FreeDesktop Launcher",
+    "descriptions": {
+        "en_US": "Generate pages with application menu entries and launch them"
+    },
+    "short-descriptions": {
+        "en_US": "Launch applications from the desktop menu"
+    },
+    "tags": ["Menu", "Launcher"],
+    "minimum-app-version": "1.0.0",
+    "app-version": "1.4.11-beta",
+    "description": "Generate pages with application menu entries and launch them.",
+    "short-description": "Launch applications from the desktop menu."
+}


### PR DESCRIPTION
## Summary
- remove the default thumbnail image from `com_fernandomema_FreeDesktopLauncher`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684d7a01c530832f99bd3719f35d2190