### PR TITLE
Fix plugin attribute use

### DIFF
--- a/com_fernandomema_StreamControllerSteamPlugin/main.py
+++ b/com_fernandomema_StreamControllerSteamPlugin/main.py
@@ -155,7 +155,7 @@ class SteamFriendsPlugin(PluginBase):
                     "0": {
                         "actions": [
                             {
-                                "id": f"{self.ID}::GameLauncher",
+                                "id": f"{self.plugin_id}::GameLauncher",
                                 "settings": {"appid": game["appid"], "name": game["name"]},
                             }
                         ],


### PR DESCRIPTION
## Summary
- fix attribute error in SteamFriendsPlugin by using `plugin_id`

## Testing
- `python -m py_compile com_fernandomema_StreamControllerSteamPlugin/main.py`

------
https://chatgpt.com/codex/tasks/task_e_684d85f02de4832fa40d2d04a6eb7893