### PR TITLE
Fix cache refresh bug

### DIFF
--- a/com_fernandomema_StreamControllerSteamPlugin/main.py
+++ b/com_fernandomema_StreamControllerSteamPlugin/main.py
@@ -239,7 +239,9 @@ class SteamFriendsPlugin(PluginBase):
 
     def refresh_friends_cache(self):
         """Refresca manualmente la caché de amigos"""
-        self._friends_cache_last_update = 0
+        # Reiniciar las estructuras de caché para evitar errores al refrescar
+        self._friends_cache = {}
+        self._friends_cache_last_update = {}
         self.friends_cache = self.get_steam_friends()
         print("[SteamFriends] Caché de amigos refrescada manualmente.")
         return self.friends_cache


### PR DESCRIPTION
## Summary
- reset friends cache dictionaries properly when refreshing

## Testing
- `python3 -m py_compile com_fernandomema_StreamControllerSteamPlugin/*.py com_fernandomema_StreamControllerSteamPlugin/actions/FriendSlot/FriendSlot.py`

------
https://chatgpt.com/codex/tasks/task_e_684d87a92368832f800cf21e19d381cd